### PR TITLE
Update SPDX Java Library to version 1.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.spdx</groupId>
   <artifactId>spdx-spreadsheet-store</artifactId>
-  <version>1.0.3-SNAPSHOT</version>
+  <version>1.0.3</version>
   <packaging>jar</packaging>
 
   <name>spdx-spreadsheet-store</name>
@@ -101,7 +101,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.0.8</version>
+    	<version>1.0.10</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.poi</groupId>
@@ -188,7 +188,7 @@
 		<plugin>
 			<groupId>org.spdx</groupId>
 				<artifactId>spdx-maven-plugin</artifactId>
-				<version>0.5.3</version>
+				<version>0.5.5</version>
 				<executions>
 					<execution>
 						<id>build-spdx</id>


### PR DESCRIPTION
updates log4j to version 2.17.0 resolving possible vulnerabilities
CVE-2021-44228 and CVE-2021-45046

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>