### PR TITLE
Update library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>spdx</sonar.organization>
     <sonar.projectKey>spdx-spreadsheet-store</sonar.projectKey>
-    <dependency-check-maven.version>7.2.1</dependency-check-maven.version>
+    <dependency-check-maven.version>8.0.1</dependency-check-maven.version>
   </properties>
   <developers>
 	<developer>
@@ -102,7 +102,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.1.2</version>
+    	<version>1.1.3</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.poi</groupId>
@@ -112,7 +112,7 @@
     <dependency>
     	<groupId>com.opencsv</groupId>
     	<artifactId>opencsv</artifactId>
-    	<version>5.5.2</version>
+    	<version>5.7.1</version>
     </dependency>
     <dependency>
     	<groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Update SPDX Java Library to version 1.1.3
Update opencsv to version 5.7.1
Note that the opencsv update resolves a potential
critical security vulnerability in an indirect
depdency:
CVE-2022-42889
Also updated is dependency-check to version 8.0.1

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>