### PR TITLE
Bump POI version to 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <dependency>
     	<groupId>org.apache.poi</groupId>
     	<artifactId>poi</artifactId>
-    	<version>5.3.0</version>
+    	<version>5.4.0</version>
     </dependency>
     <dependency>
     	<groupId>com.opencsv</groupId>
@@ -166,7 +166,7 @@
     <dependency>
     	<groupId>org.apache.poi</groupId>
     	<artifactId>poi-ooxml</artifactId>
-    	<version>5.3.0</version>
+    	<version>5.4.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Resolves Improper Input Validation vulnerability in Apache POI.