### PR TITLE
Handle when row.getCell() is null

### DIFF
--- a/src/main/java/org/spdx/spreadsheetstore/AnnotationsSheet.java
+++ b/src/main/java/org/spdx/spreadsheetstore/AnnotationsSheet.java
@@ -195,7 +195,8 @@ public class AnnotationsSheet extends AbstractSheet {
 		if (row == null) {
 			return null;
 		}
-		return row.getCell(ID_COL).getStringCellValue();
+		Cell cell = row.getCell(ID_COL);
+		return cell != null ? cell.getStringCellValue() : null;
 	}
 
 	/**

--- a/src/main/java/org/spdx/spreadsheetstore/RelationshipsSheet.java
+++ b/src/main/java/org/spdx/spreadsheetstore/RelationshipsSheet.java
@@ -192,7 +192,8 @@ public class RelationshipsSheet extends AbstractSheet {
 		if (row == null) {
 			return null;
 		}
-		return row.getCell(ID_COL).getStringCellValue();
+		Cell cell = row.getCell(ID_COL);
+		return cell != null ? cell.getStringCellValue() : null;
 	}
 	
 	public Relationship getRelationship(int rowNum) throws SpreadsheetException {

--- a/src/main/java/org/spdx/spreadsheetstore/SnippetSheet.java
+++ b/src/main/java/org/spdx/spreadsheetstore/SnippetSheet.java
@@ -448,8 +448,8 @@ public class SnippetSheet extends AbstractSheet {
 		}
 		SpdxFile snippetFromFile = (SpdxFile)moFromFile.get();
 		
-		if (Objects.isNull(row.getCell(BYTE_RANGE_COL)) && row.getCell(BYTE_RANGE_COL).getStringCellValue().trim().isEmpty()) {
-			throw new SpreadsheetException("Missing reqired byte range for Snippet ID "+id);
+		if (Objects.isNull(row.getCell(BYTE_RANGE_COL)) || row.getCell(BYTE_RANGE_COL).getStringCellValue().trim().isEmpty()) {
+			throw new SpreadsheetException("Missing required byte range for Snippet ID "+id);
 		}
 			String range = row.getCell(BYTE_RANGE_COL).getStringCellValue();
 			int start = 0;


### PR DESCRIPTION
`row.getCell()` can be null.

Check that before do cell `.getStringCellValue()` to prevent null pointer exception