### PR TITLE
Optimize copyPackageInfoToSS

### DIFF
--- a/src/main/java/org/spdx/spreadsheetstore/SpreadsheetStore.java
+++ b/src/main/java/org/spdx/spreadsheetstore/SpreadsheetStore.java
@@ -359,7 +359,7 @@ public class SpreadsheetStore extends ExtendedSpdxStore implements ISerializable
 			PackageInfoSheet packageInfoSheet, ModelCopyManager copyManager,
 			Map<String, Collection<ExternalRef>> externalRefs,
 			Map<String, Collection<Relationship>> allRelationships, Map<String, Collection<Annotation>> allAnnotations) throws InvalidSPDXAnalysisException {
-		Map<String, String> fileIdToPkgId = new HashMap<>();
+		Map<String, List<String>> fileIdToPkgIds = new HashMap<>();
 		List<SpdxPackage> packages;
 		
 		try (@SuppressWarnings("unchecked")
@@ -372,14 +372,7 @@ public class SpreadsheetStore extends ExtendedSpdxStore implements ISerializable
 			String pkgId = pkg.getId();
 			Collection<SpdxFile> files = pkg.getFiles();
 			for (SpdxFile file:files) {
-				String fileId = file.getId();
-				String pkgIdsForFile = fileIdToPkgId.get(fileId);
-				if (pkgIdsForFile == null) {
-					pkgIdsForFile = pkgId;
-				} else {
-					pkgIdsForFile = pkgIdsForFile + ", " + pkgId;
-				}
-				fileIdToPkgId.put(fileId, pkgIdsForFile);
+				fileIdToPkgIds.computeIfAbsent(file.getId(), k -> new ArrayList<>()).add(pkgId);
 			}
 			Collection<ExternalRef> pkgExternalRefs = pkg.getExternalRefs();
 			if (pkgExternalRefs != null && pkgExternalRefs.size() > 0) {
@@ -394,6 +387,10 @@ public class SpreadsheetStore extends ExtendedSpdxStore implements ISerializable
 			if (annotations.size() > 0) {
 				allAnnotations.put(pkg.getId(), annotations);
 			}
+		}
+		Map<String, String> fileIdToPkgId = new HashMap<>();
+		for (Entry<String, List<String>> entry : fileIdToPkgIds.entrySet()) {
+			fileIdToPkgId.put(entry.getKey(), String.join(", ", entry.getValue()));
 		}
 		return fileIdToPkgId;
 	}


### PR DESCRIPTION
Optimize string concatenation in `SpreadsheetStore.copyPackageInfoToSS()` by collecting package IDs into a `List<String>` per file ID and concatenate all of them at once.

Reduce String object allocation and GC overhead. Reduce String construction time to linear.

The method signature stays the same. Output order stays the same.
